### PR TITLE
Fix issue with large timestamp arrays

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-deckgl/src/utils/time.js
+++ b/packages/superset-ui-legacy-preset-chart-deckgl/src/utils/time.js
@@ -77,8 +77,8 @@ function getStepSeconds(step, start) {
 }
 
 export function getPlaySliderParams(timestamps, timeGrain) {
-  const minTimestamp = moment(Math.min(...timestamps));
-  const maxTimestamp = moment(Math.max(...timestamps));
+  const minTimestamp = moment(Number(timestamps.reduce((a,b) => a<b ? a:b)));
+  const maxTimestamp = moment(Number(timestamps.reduce((a,b) => a>b ? a:b)));
   let step;
   let reference;
 


### PR DESCRIPTION
Math.max and Math.min produce "Maximum call stack size exceeded" errors when used with large arrays (see: https://stackoverflow.com/questions/18308700/chrome-how-to-solve-maximum-call-stack-size-exceeded-errors-on-math-max-apply)

🐛 Bug Fix
